### PR TITLE
ci(github action): add libpng-dev system dependency

### DIFF
--- a/.github/workflows/quarto_publish.yaml
+++ b/.github/workflows/quarto_publish.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           r-version: '4.4.1'
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpng-dev
+
       - name: Setup renv
         uses: r-lib/actions/setup-renv@v2
 


### PR DESCRIPTION
This fixes the GitHub action, which was failing when attempting to build the renv for the quarto documentation website.